### PR TITLE
Add skill: TeoSlayer/pilot-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1854,6 +1854,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
 - **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
 - **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[TeoSlayer/pilot-skills](https://github.com/TeoSlayer/pilot-skills)** - Agent-to-agent messaging, file sync, and trust over Pilot Protocol
 
 </details>
 


### PR DESCRIPTION
Adds TeoSlayer/pilot-skills to the Specialized Domains community skills section.

pilot-skills is a real, community-used collection of agent skills built on Pilot Protocol (an overlay network for AI agents). Each skill wraps `pilotctl` for a focused capability — messaging, file sync, trust management, task routing, and swarm coordination between agents. Public repo with documentation, author prefix included, no existing listing for this repo in the README.