### PR TITLE
Add skill: zincio/universal-checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1898,6 +1898,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[GarethManning/competency-unpacker](https://github.com/GarethManning/education-agent-skills/tree/main/skills/curriculum-assessment/competency-unpacker)** - Unpacks broad competencies into assessable sub-skills and success criteria
 - **[ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills)** - Agent skills for YouTube: pull video transcripts and discover videos (search, channel and playlist listings) via TranscriptAPI.
 - **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
+- **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 
 </details>
 


### PR DESCRIPTION
Follows @necatiozmen's note on #915: submitting Zinc as a **single Community Skills entry** under Specialized Domains — no dedicated "Skills by Zinc" section.

- **Skill:** [zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)
- Official [Zinc API](https://zinc.com) at zinc.com (programmatic checkout across Amazon, Walmart, Target, and 50+ US retailers) — not the chemical ZINC database
- Install: `npx skills add zincio/skills --skill universal-checkout`
- Docs: https://www.zinc.com/docs/v2/agent-skills/overview

Added to the end of **Community Skills → Specialized Domains**, matching the existing one-line format.