### PR TITLE
Add skill: dannwaneri/spec-writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1831,6 +1831,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 - **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
+- **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
 
 </details>
 


### PR DESCRIPTION
Adds spec-writer to the Development and Testing section.

spec-writer turns a vague feature request into a technology-agnostic spec, a technical plan, and an ordered task breakdown in one invocation, flagging every unstated assumption inline (`[ASSUMPTION: ...]`) so a reviewer corrects rather than interrogates. Output format is compatible with GitHub Spec Kit and OpenSpec.

- Public repo with README and SKILL.md documentation
- Works as an Agent Skill across Claude Code, Cursor, and Gemini CLI
- Repo: https://github.com/dannwaneri/spec-writer