### PR TITLE
Add skill: 1102tools-dev/federal-contracting-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1910,7 +1910,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
-- **[1102tools/federal-contracting-skills](https://github.com/1102tools-dev/federal-contracting-skills/tree/main/skills)** - Federal acquisition workflows for research, SOW/PWS, IGCE, policy, and OTs
+- **[1102tools-dev/federal-contracting-skills](https://github.com/1102tools-dev/federal-contracting-skills/tree/main/skills)** - Federal acquisition workflows for research, SOW/PWS, IGCE, policy, and OTs
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1910,6 +1910,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything)** - Reverse-engineer binaries, applications, and runtimes with REA
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
+- **[1102tools/federal-contracting-skills](https://github.com/1102tools-dev/federal-contracting-skills/tree/main/skills)** - Federal acquisition workflows for research, SOW/PWS, IGCE, policy, and OTs
 
 </details>
 


### PR DESCRIPTION
Adds the maintained 1102tools federal contracting skill collection under Specialized Domains.

The public MIT-licensed repository contains nine documented, tested SKILL.md workflows for federal acquisition research, SOW/PWS development, IGCEs, acquisition policy, GovCon growth, and Other Transactions. It has 25 GitHub stars and a public testing record.