### PR TITLE
Add skill: scarletkc/agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1831,6 +1831,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 - **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
+- **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 
 </details>
 


### PR DESCRIPTION
## Summary

- add `scarletkc/agents` to `Development and Testing`
- link a public collection of six reusable skills for coding-agent workflows

## Why it fits

`scarletkc/agents` supports Claude Code, Codex CLI, and other Agent Skills-compatible tools. The repository has 101 GitHub stars, an Apache-2.0 license, documented installation, and passing skill validation.

## Checks

- confirmed the source link returns 200
- kept the list description to 9 words
- checked the current README and PRs for duplicates