### PR TITLE
Add skill: rainmanjam/poka-yoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -1831,6 +1831,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 - **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
+- **[rainmanjam/poka-yoke](https://github.com/rainmanjam/poka-yoke)** - Make misuse unrepresentable: audit, design, and enforce mistake-proofing devices
 
 </details>
 


### PR DESCRIPTION
Adds **poka-yoke** to Community Skills → Development and Testing.

Eleven skills plus a dependency-free hazard scanner, applying Shigeo Shingo's
mistake-proofing method to code: prefer a device that makes a wrong action impossible or
self-announcing over an instruction asking someone to avoid it.

- Repo: https://github.com/rainmanjam/poka-yoke
- License: MIT
- Description is 9 words, within the 10-word guideline

One line added, inside the existing `Development and Testing` group. No other changes.