### PR TITLE
Add Persona — local-first workspace with built-in MCP server (15 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 # Awesome Agent Skills
 
+- [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: notes, tasks, and AI chat over plain Markdown files. Connects to Ollama for free private AI.
 Unlike many bulk-generated skill repositories, this collection focuses on real-world Agent Skills created and used by actual engineering teams, not mass AI‑generated stuff.
 
 This collection features official skills published by leading development teams, including Anthropic, Google Labs, Vercel, Stripe, Cloudflare, Netlify, Trail of Bits, Sentry, Expo, Hugging Face, Figma, and more, alongside community-built skills.


### PR DESCRIPTION
Add [Persona](https://github.com/jayamitkatariya/personacli) — a local-first personal workspace whose notes/tasks are exposed as 15 MCP tools. Agents can read/write a plain-Markdown knowledge base directly. Ollama-powered AI included. MIT.