### PR TITLE
Add stop-manual-testing to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1833,6 +1833,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 - **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
+- **[Kaiji-Z/stop-manual-testing](https://github.com/Kaiji-Z/stop-manual-testing)** - Stop manually testing AI agents: diagnoses project verifiability, then builds a machine-checkable verification system (regression suite, two-layer judge, GATE compliance mechanism) so the agent self-verifies and converges in a closed loop
 
 </details>
 


### PR DESCRIPTION
## What skill does this PR add?

**[Kaiji-Z/stop-manual-testing](https://github.com/Kaiji-Z/stop-manual-testing)** — stops you from manually testing your AI agent.

Agent developers spend ~90% of dev time manually testing: clicking through the UI, watching the agent run, judging by gut feel whether it got better or worse. This skill:

- Runs a 7-step read-only diagnosis of the project's verifiability (ACI audit: UI-independent runs, logged intermediate state, programmatic interfaces)
- Builds a machine-checkable verification system: regression suite, two-layer judge (deterministic assertions + clean-context LLM supervisor), flag-based A/B
- Uses a GATE (Declare-Verify-Enforce) mechanism so agent compliance is visible and checkable
- Orchestrates existing eval tools (DeepEval / LangSmith / pytest / jest) instead of reinventing

Compatible with Claude Code, Codex, and any agent supporting standard skill paths. MIT, self-contained, no runtime dependencies.

> Note: this re-submits #942 (closed during backlog cleanup) rebased onto current main — the old branch was 5 weeks stale. Entry appended at the end of the Development and Testing section per current convention.