### PR TITLE
Add skill-audit to recommended security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1944,6 +1944,7 @@ Recommended tools:
 
 - [Synk Skill Security Scanner](https://github.com/snyk/agent-scan)
 - [Agent Trust Hub](https://ai.gendigital.com/agent-trust-hub)
+- [skill-audit](https://github.com/FrankFu916/skill-audit) — zero-dependency CLI that statically audits SKILL.md packages for prompt injection, credential exfiltration, destructive commands, and spec violations before you install them (`npx @frankfu0916/skill-audit ~/.claude/skills`)
 
 Agent skills can include prompt injections, tool poisoning, hidden malware payloads, or unsafe data handling patterns. Always review the code and use skills at your own discretion.
 


### PR DESCRIPTION
## What

Adds [skill-audit](https://github.com/FrankFu916/skill-audit) to the **Recommended tools** list in the 🔒 Security Notice section, alongside Snyk's agent-scan and Agent Trust Hub.

## Why it fits

The Security Notice says skills are *curated, not audited* — this tool is exactly the missing audit step for an individual user, run locally before install:

```bash
npx @frankfu0916/skill-audit ~/.claude/skills
```

It statically scans any `SKILL.md` package (works for Claude Code / Codex / Cursor / OpenCode layouts per the paths table above) for prompt injection (hidden HTML comments, zero-width smuggling), credential exfiltration (`~/.ssh`/AWS/ reads paired with network calls), destructive commands, obfuscated payloads, and Agent Skills spec violations — 24 explainable rules, a 0–100 score per skill, SARIF/JSON output for CI.

## Quality signals

- Zero runtime dependencies, Node ≥ 18, MIT; static analysis only (never executes scanned content)
- 34 unit + e2e tests; CI matrix: linux/macOS/windows × Node 18/20/22/24 ([green](https://github.com/FrankFu916/skill-audit/actions))
- Rule set calibrated against the official [anthropics/skills](https://github.com/anthropics/skills) corpus (19 real skills audited; false positives on legit patterns like LibreOffice `-env:` flags fixed)
- Published on npm as [`@frankfu0916/skill-audit`](https://www.npmjs.com/package/@frankfu0916/skill-audit)

Happy to adjust placement/wording. Related roadmap item if useful: community scores could later feed the Skill Quality Standards section.