### PR TITLE
Add skill: winterbim/wincreator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1833,6 +1833,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 - **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
+- **[winterbim/wincreator](https://github.com/winterbim/wincreator)** - Proof-gated engineering loops with a mechanical ledger
 
 </details>
 


### PR DESCRIPTION
Adds **winterbim/wincreator** at the end of Development and Testing.

Public Agent Skill (MIT) that keeps engineering claims in a Proof Ledger, captures the command that was actually run, and separates Builder from Skeptic so an agent cannot mark its own work done.

- Repo: https://github.com/winterbim/wincreator
- Skill path: `skill/wincreator/SKILL.md`
- Install: `npx skills add winterbim/wincreator`

Description is 8 words, matching CONTRIBUTING.


Made with [Cursor](https://cursor.com)