### PR TITLE
Add skill: vaibhavarora14/job-application-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1746,6 +1746,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[zapier/zapier-mcp](https://github.com/zapier/zapier-mcp)** - Official plugin distribution for the hosted Zapier MCP server. Connects Claude to thousands of apps — send messages, pull data, trigger workflows.
 - **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
 - **[kgraph57/strategy-consulting-visualization](https://github.com/kgraph57/mckinsey-style-visualization-skill)** - McKinsey-style charts and consulting slide decks
+- **[vaibhavarora14/job-application-agent](https://github.com/vaibhavarora14/job-application-agent)** - Privacy-first job discovery and tracking
 
 </details>
 


### PR DESCRIPTION
## Summary

Please add vaibhavarora14/job-application-agent under Community Skills, Productivity and Collaboration.

This is a public, working Agent Skill with README and SKILL.md, released under MIT.
- GitHub: https://github.com/vaibhavarora14/job-application-agent (137 stars)
- Weekly downloads about 3000 on the Node package registry
- Install: job-application-agent latest install command documented in the repo README

Please list it at the end of Community Skills, Productivity and Collaboration.
