### PR TITLE
Add skill: Kayforkind/reimagine-it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1833,8 +1833,9 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[aeonfun/aeon](https://github.com/aeonfun/aeon)** - 70+ Claude Code skills + autonomous GitHub Actions agent framework
 - **[KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template)** - Plan MVPs into PRD, tech design, and AGENTS.md
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
-- **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[Kayforkind/reimagine-it](https://github.com/Kayforkind/reimagine-it)** - Redesigns existing HTML pages from their own content
+- **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 
 </details>
 


### PR DESCRIPTION
Content-derived design skill — reads existing HTML and redesigns it from its own content (palette, motifs, and motion derived from source facts). Ships as an agent skill, npm CLI, MCP server, and GitHub Action for Design Health.

- npm: [reimagine-it](https://www.npmjs.com/package/reimagine-it) (v2.3.7, 46 unit tests, 15 direction tokens, 18.4% output diversity)
- Skills.sh: [link](https://skills.sh/kayforkind/reimagine-it)
- Playground: [Try it live](https://kayforkind.github.io/reimagine-it/#playground)