### PR TITLE
Add kaoyan-skills: Chinese exam-prep skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1730,6 +1730,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[kreuzberg-dev/xberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/plugin/skills/xberg)** - Extract text, tables, and metadata from 101+ document formats
 - **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
 - **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- **[CAlM123451/kaoyan-skills](https://github.com/CAlM123451/kaoyan-skills)** - Chinese exam-prep skills for AI coding agents: study planning, mistake analysis, English reading, medical mnemonics, self-testing, and Ebbinghaus spaced repetition
 - **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
 - **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
 - **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting


### PR DESCRIPTION
## Add kaoyan-skills

Adding [kaoyan-skills](https://github.com/CAlM123451/kaoyan-skills) to the Productivity and Collaboration section.

**kaoyan-skills** is a collection of Chinese exam-prep skills for AI coding agents (Claude Code / Agent Skills spec). It covers:
- Study planning with phased schedules
- Mistake analysis and weak point identification  
- English reading comprehension (long sentence parsing)
- Medical mnemonics generation
- Self-testing with exam-style questions
- Ebbinghaus spaced repetition scheduling

Pure markdown skills, MIT licensed, drop-in compatible with Claude Code's \.claude/skills/\ directory.

Placed in the Productivity and Collaboration section alongside other education/study-related skills like tutor-skills.