### PR TITLE
Add skill: ScrapeCreators/social-media-research-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,6 +1701,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[YannisKiefer/dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills)** - 13 sales and negotiation skills for agents distilled from 36 books (CIA psyop manuals, FBI behavioral research, propaganda science, persuasion classics); every tactic passes an honest-influence filter: it must still work when fully disclosed
 - **[SupercmoHQ/superCMO-skills](https://github.com/SupercmoHQ/superCMO-skills)** - Open-source skills + local MCP server for marketing video & image production: UGC videos, ad videos, product photography, and image ads from a product photo and a brief; casts AI actors, picks the best image/video models, edits any-length clips with consistent actor and product, and researches competitor ads. BYO or managed keys, Apache-2.0
 - **[sandbaseai/sandbase-skills/multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/main/research/multi-source-search)** - Evidence-led multi-source research with offline validation
+- **[ScrapeCreators/social-media-research-skills](https://github.com/ScrapeCreators/social-media-research-skills)** - Research social outliers, comments, competitors, ads, and trends
 
 </details>
 


### PR DESCRIPTION
Adds ScrapeCreators' established social media research skill collection to Community Skills / Marketing.

The entry follows the required `author/skill-name` format, links to the public repository, and uses an 8-word description.

## Verification

- ✅ Repository link returns HTTP 200
- ✅ Entry added to the end of Community Skills / Marketing
- ✅ Description is 8 words (10-word limit)
- ✅ `git diff --check`
