### PR TITLE
Add falsify: scientific thinking protocol skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1870,6 +1870,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 </details>
 
 <details>
+- **[263311487-ux/falsify](https://github.com/263311487-ux/falsify)** - The scientific thinking protocol for AI agents: axioms → hypothesis → adversarial test → evidence → calibrated verdict; stops agents from giving confident answers they cannot falsify (28 evals, works with 20+ agents, npm: falsify-skill)
 <summary><h3 style="display:inline">Specialized Domains</h3></summary>
 
 - **[shouldnotappearcalm/a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill)** - China A-share (Shanghai/Shenzhen) skills: real-time quotes, K-line history, technical indicators, events, capital flows, sector heatmaps, and paper trading. Works with Claude Code, Cursor, Codex, and Qoder


### PR DESCRIPTION
## Add [falsify](https://github.com/263311487-ux/falsify) to Community Skills → Context Engineering

**falsify** is the scientific thinking protocol for AI agents — axioms → hypothesis → adversarial test → evidence → calibrated verdict. It stops agents from giving confident answers they cannot falsify.

- Single-Markdown skill, works with 20+ agents (Codex, Claude Code, Cursor, Gemini CLI, ...)
- Distilled from 70+ community sources + ICML 2026 / NeurIPS / Kahneman / Galef / Snowden / Kepner-Tregoe / Boyd
- 28 evaluation cases, 4/4 external dogfood cross-validation passed
- Also on npm: `npx falsify-skill`