### PR TITLE
Add skill: cis2042/product-design-harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1930,6 +1930,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[czlonkowski/n8n-node-configuration](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-node-configuration)** - Node configuration with dependency rules and AI connections
 - **[czlonkowski/n8n-validation-expert](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-validation-expert)** - Fix n8n validation errors with error catalog
 - **[czlonkowski/n8n-workflow-patterns](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-workflow-patterns)** - Workflow patterns for webhook, HTTP, database, and AI tasks
+- **[cis2042/product-design-harness](https://github.com/cis2042/product-design-harness)** - Reviews product decisions before execution across user, evidence, business flows
 
 </details>
 


### PR DESCRIPTION
Adds UX3 Product Design Harness to Community Skills.

**What it does:** Reviews a product decision before execution and returns one machine-checkable verdict — `continue`, `verify`, or `stop_reframe`. Three reviewer agents (User Flow, Evidence Flow, Business Flow) each produce an independent verdict; a fourth separates evidence tier from confidence to cap action size by proof strength.

**Why it may be worth listing:** Most design-related skills operate on artifacts — components, tokens, copy, visuals. This one operates on the decision: what should be built, for whom, on what evidence. Taste, ethics, strategy, risk appetite, and final accountability stay named human-owned fields rather than optional escalations.

**Contents:** 21 declarative decision rules, 19 JSON Schemas, an ontology, 4 reviewer agent definitions, golden examples, and a `jsonschema`-based validator. Framework-agnostic — no server, no SDK. MIT. 8 working languages.

**Quality checks:** `SKILL.md` is 126 lines, no absolute paths, resources loaded on demand from `skills/product-design-harness/resources/`.

**Disclosure:** I am the author. Created 2026-07-11, so it is not community-proven at scale yet — happy for you to decline on that basis, or resubmit later.
