### PR TITLE
Add skill: Codyte/Tia-Portal-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1917,6 +1917,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 - **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
+- **[Codyte/Tia-Portal-CLI](https://github.com/Codyte/Tia-Portal-CLI)** - Siemens TIA Portal automation via the Openness API: 108 CLI verbs with JSON in and out for PLC blocks, tags, hardware, compile, and simulation, write verbs dry-run by default
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1917,7 +1917,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 - **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
-- **[Codyte/Tia-Portal-CLI](https://github.com/Codyte/Tia-Portal-CLI)** - Siemens TIA Portal automation via the Openness API: 108 CLI verbs with JSON in and out for PLC blocks, tags, hardware, compile, and simulation, write verbs dry-run by default
+- **[Codyte/Tia-Portal-CLI](https://github.com/Codyte/Tia-Portal-CLI)** - Drive Siemens TIA Portal from the CLI via Openness
 
 </details>
 


### PR DESCRIPTION
Adds `Codyte/Tia-Portal-CLI` to Community Skills > Specialized Domains.

Drives Siemens TIA Portal through the Openness API from the command line: 108 verbs with JSON input and output covering project reads, block export/import, tags, hardware, compile, and PLCSIM simulation. Write verbs are dry-run by default and require an explicit `--apply`.

- Repo: https://github.com/Codyte/Tia-Portal-CLI
- `SKILL.md` at the repo root, plus docs and an installation runbook
- Public, AGPL-3.0, first commit 2026-07-17, active development