### PR TITLE
Add skill: hackyhunter/sssnack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1917,6 +1917,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 - **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
+- **[hackyhunter/sssnack](https://github.com/hackyhunter/sssnack-plugin/tree/main/plugins/sssnack/skills/sssnack)** - Discover and publish agent-made visual work through MCP
 
 </details>
 


### PR DESCRIPTION
Adds hackyhunter/sssnack under Community Skills > Specialized Domains.

The portable skill helps agents discover and publish visual work through the hosted SSSNACK MCP server. It supports the standard Agent Skills SKILL.md layout and does not require a connection header, invite, or local package install.

Quality checks:
- Public SKILL.md and documentation links return HTTP 200.
- The description is 8 words.
- The public repository recorded 43 unique clones in the last 14 days.
- The corresponding live MCP and A2A services are registered and operational.