### PR TITLE
Fix skills-count badge (1497+ -> 1224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <div align="center">
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Skills Count](https://img.shields.io/badge/Skills-1497+-blue?style=flat-square)
+![Skills Count](https://img.shields.io/badge/Skills-1224-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-agent-skills?label=Last%20update&style=flat-square)
 <a href="https://github.com/VoltAgent/voltagent">
   <img alt="VoltAgent" src="https://cdn.voltagent.dev/website/logo/logo-2-svg.svg" height="20" />


### PR DESCRIPTION
## Summary

The header badge reads `Skills-1497+`, but the README lists ~1,224 skill entries (637 GitHub skill paths + 578 `officialskills.sh` links). This corrects the count to match the actual listing.

`+1 / −1` — a single badge value change.