### PR TITLE
Add skill: d1vai/d1v

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[d1vai/d1v](https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md)** - Deploy web projects with verified previews and confirmed production releases
 
 </details>
 


### PR DESCRIPTION
## Summary

- add the official d1v deployment Skill to Development and Testing
- link directly to the public canonical `SKILL.md` in `d1vai/d1v-cli`

The Skill guides verified preview deployments and explicit-confirmation production releases.