### PR TITLE
Add skill-vet to Security Notice recommended tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1946,6 +1946,7 @@ Recommended tools:
 
 - [Synk Skill Security Scanner](https://github.com/snyk/agent-scan)
 - [Agent Trust Hub](https://ai.gendigital.com/agent-trust-hub)
+- [skill-vet](https://github.com/ruslanlap/skill-vet) — static scanner for SKILL.md skill bundles: prompt injection, data exfiltration, credential harvesting, destructive commands; false-positive allowlist, GitHub Action + SARIF, also installable as an agent skill (Claude Code / Codex / Hermes).
 
 Agent skills can include prompt injections, tool poisoning, hidden malware payloads, or unsafe data handling patterns. Always review the code and use skills at your own discretion.
 


### PR DESCRIPTION
Adds [skill-vet](https://github.com/ruslanlap/skill-vet), an open-source static security scanner for SKILL.md skill bundles (prompt injection, data exfiltration, credential harvesting, destructive commands), to the Recommended tools list in the Security Notice. It fits alongside the existing entries as a free, self-hostable way for users to validate skills before installing them: MIT-licensed, zero dependencies, 22 passing tests, CI green, with a false-positive allowlist, a GitHub Action + SARIF output, and an installable agent-skill package (Claude Code / Codex / Hermes).