### PR TITLE
Add skill: blitzsicht/falzmarke

### DIFF
--- a/README.md
+++ b/README.md
@@ -1746,6 +1746,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[zapier/zapier-mcp](https://github.com/zapier/zapier-mcp)** - Official plugin distribution for the hosted Zapier MCP server. Connects Claude to thousands of apps — send messages, pull data, trigger workflows.
 - **[Neeeophytee/finding-unknowns-skills](https://github.com/Neeeophytee/finding-unknowns-skills)** - 8 meta-skills that make a coding agent surface your unknowns before they get expensive: blindspot pass, interview, reference hunt, implementation plan/notes, pitch packager, and a pre-merge change quiz. Works in Claude Code, Codex, and Cursor via the agentskills.io SKILL.md format
 - **[kgraph57/strategy-consulting-visualization](https://github.com/kgraph57/mckinsey-style-visualization-skill)** - McKinsey-style charts and consulting slide decks
+- **[blitzsicht/falzmarke](https://github.com/blitzsicht/falzmarke)** - German DIN 5008 business letters from Markdown to PDF/A
 
 </details>
 


### PR DESCRIPTION
Adding [blitzsicht/falzmarke](https://github.com/blitzsicht/falzmarke) to **Community Skills > Productivity and Collaboration** (moving it to `Other` is fine if you prefer).

`- **[blitzsicht/falzmarke](https://github.com/blitzsicht/falzmarke)** - German DIN 5008 business letters from Markdown to PDF/A`

Nine words, author prefix included, one line at the end of the subcategory.

Public repo, MIT, documented in both README and `skill/SKILL.md`. It is more than a single SKILL.md: a Python package on PyPI (`falzmarke`), a CLI, an optional MCP server, a GitHub Action, and packaged `.skill` bundles for claude.ai. It writes German business letters from Markdown, typesets them to PDF/A via Typst, and then measures the produced PDF — 33 geometry checks with millimetre tolerances, each one covered by a counter-test against a deliberately shifted layout.

In fairness to your guidelines: the repository is new (first commit 2026-08-25) and has no stars yet, so it does not meet the community-adoption bar you describe. Close this if it is too early — no hard feelings, and I will resubmit once it has users.