### PR TITLE
Add Understand-JS-malware skill set to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1802,7 +1802,9 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[NeoLabHQ/kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen)** - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
 - **[uucz/moyu](https://github.com/uucz/moyu)** - Anti-over-engineering skill with 5 variants and 10 platforms
 - **[mattpocock/skills](https://github.com/mattpocock/skills)** - 17 dev workflow skills: PRD writing, TDD, codebase architecture, git guardrails, issue triage, refactoring plans, and more
-- **[mukul975/Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills)** - 753 cybersecurity skills across 38 domains: cloud security, pentesting, red teaming, DFIR, malware analysis, threat intel, and more (MITRE ATT&CK mapped)
+- **[mukul975/Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills)**
+- **[rz-x/Understand-JS-malware---skills-tools-set](https://github.com/rz-x/Understand-JS-malware---skills-tools-set)** - 5 agent skills for JavaScript malware triage, AST deobfuscation, npm package inspection, supply chain attribution, and detection rules
+ - 753 cybersecurity skills across 38 domains: cloud security, pentesting, red teaming, DFIR, malware analysis, threat intel, and more (MITRE ATT&CK mapped)
 - **[wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)** - Secure environment variable management ensuring secrets are never exposed in Claude sessions, terminals, logs, or git commits
 - **[Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Automatically convert documentation websites, GitHub repositories, and PDFs into Claude AI skills in minutes
 - **[NoizAI/skills](https://github.com/NoizAI/skills)** - Human-like TTS workflows with local/cloud APIs and app delivery


### PR DESCRIPTION
### Description
Adds **[rz-x/Understand-JS-malware---skills-tools-set](https://github.com/rz-x/Understand-JS-malware---skills-tools-set)** to Community Skills under Development and Testing / Security.

- **Set of 5 agent skills**: , , , , and .
- Follows the standard  Agent Skills format with references and scripts. Compatible with Claude Code, Cursor, Hermes Agent, and Codex.