### PR TITLE
Add skill: ssheleg/task-pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[ssheleg/task-pipeline](https://github.com/ssheleg/task-pipeline/tree/main/plugins/task-pipeline/skills/task-pipeline)** - Runs repository changes through ten gated delivery stages
 
 </details>
 


### PR DESCRIPTION
Adds [ssheleg/task-pipeline](https://github.com/ssheleg/task-pipeline/tree/main/plugins/task-pipeline/skills/task-pipeline) to Development and Testing.

The skill runs substantial repository changes through gated stages from intake to acceptance. It is public, documented, installable, and maintained in a tagged repository.

The README entry follows the required author prefix and eight-word description.