### PR TITLE
Add skill: Hahaknight/claude-skills-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,7 +1835,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
-- **[Hahaknight/claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro)** - 15 engineering-workflow skills: 7-dimension PR review, root-cause debugging, mutation-checked test generation, safe DB migrations; 5 free under MIT
+- **[Hahaknight/claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro)** - 15 engineering-workflow skills: 7-dimension PR review, root-cause debugging, mutation-checked test generation, safe DB migrations; 6 free under MIT
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[Hahaknight/claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro)** - 15 engineering-workflow skills: 7-dimension PR review, root-cause debugging, mutation-checked test generation, safe DB migrations; 5 free under MIT
 
 </details>
 


### PR DESCRIPTION
## Summary

- add `Hahaknight/claude-skills-pro` to `Development and Testing`
- a pack of 15 engineering-workflow skills: 7-dimension PR review, root-cause debugging (reproduce → bisect → single hypothesis), mutation-checked test generation, zero-downtime DB migrations, behavior-preserving refactors, and more

## Why it fits

- Agent Skills-compatible: installs with `npx skills add Hahaknight/claude-skills-pro` and works with Claude Code, Codex CLI, Cursor, and other SKILL.md-compatible agents
- 7 of the 15 skills are free and open source under MIT; each ships as a standard `SKILL.md` with trigger rules, workflow, output format, and anti-patterns
- documented installation (npx / bash / PowerShell), GitHub Pages catalog, and frontmatter validated on all shipped skills
- the repo is new (published this week), so it has no stars yet — the free skills and the install docs are up for anyone to verify directly

## Checks

- confirmed the source repo and install command work end-to-end (`npx skills add` resolved and installed the free skills)
- single line added under `Development and Testing`, matching the existing entry format

