### PR TITLE
Add skill: Nanako0129/sepia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,6 +1701,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[YannisKiefer/dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills)** - 13 sales and negotiation skills for agents distilled from 36 books (CIA psyop manuals, FBI behavioral research, propaganda science, persuasion classics); every tactic passes an honest-influence filter: it must still work when fully disclosed
 - **[SupercmoHQ/superCMO-skills](https://github.com/SupercmoHQ/superCMO-skills)** - Open-source skills + local MCP server for marketing video & image production: UGC videos, ad videos, product photography, and image ads from a product photo and a brief; casts AI actors, picks the best image/video models, edits any-length clips with consistent actor and product, and researches competitor ads. BYO or managed keys, Apache-2.0
 - **[sandbaseai/sandbase-skills/multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/main/research/multi-source-search)** - Evidence-led multi-source research with offline validation
+- **[Nanako0129/sepia](https://github.com/Nanako0129/sepia)** - De-AI writing skill fixing narrative structure before word choice
 
 </details>
 


### PR DESCRIPTION
Adds sepia to Community Skills → Marketing, at the end of the section per CONTRIBUTING.

- Repo: https://github.com/Nanako0129/sepia (MIT, public, README + SKILL.md present)
- What it is: a de-AI writing skill built from the StoryScope paper (arXiv:2604.03136) and the related studies digested in the repo's research/ folder. Narrative-structure repair for fiction; venue-matched rules for professional writing (release notes, PR replies, postmortems, tickets, tech articles).
- Category follows the existing de-AI entries in Marketing (blader/humanizer, MohamedAbdallah-14/unslop).
- Links verified; searched existing entries and PRs for duplicates, none found.