### PR TITLE
Add claude-ai-agents-ios to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[apexbymanish/claude-ai-agents-ios](https://github.com/apexbymanish/claude-ai-agents-ios)** - iOS/Swift subagents & skills with an evidence-tiered claim-verification system
 
 </details>
 


### PR DESCRIPTION
Adds [claude-ai-agents-ios](https://github.com/apexbymanish/claude-ai-agents-ios): iOS/Swift subagents & skills with an evidence-tiered claim-verification system, under the Development and Testing community category.

Heads up: this is a new repo without established community usage yet, which I saw your CONTRIBUTING guide asks for — feel free to close if that's a hard requirement rather than a general guideline.