### PR TITLE
Add skill: tt-a1i/archify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,6 +1835,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[tt-a1i/archify](https://github.com/tt-a1i/archify/tree/main/archify)** - Generate validated interactive architecture diagrams from codebases or system descriptions
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add `tt-a1i/archify` to Community Skills → Development and Testing.
- Archify generates validated, interactive architecture diagrams from codebases or system descriptions.

## Why it fits

- Public MIT-licensed repository with a working `SKILL.md`
- Supports Claude Code, Codex, Cursor, OpenCode, and other Agent Skills-compatible tools
- Actively maintained with established community adoption

## Validation

- [x] Link is valid
- [x] Description is 10 words
- [x] Added to the end of the matching community category
- [x] No unrelated changes