### PR TITLE
Add skill: anzy-renlab-ai/pronounce-word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1856,6 +1856,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[anzy-renlab-ai/pronounce-word](https://github.com/anzy-renlab-ai/pronounce/tree/main/skills/pronounce-word)** - Pronounce developer jargon with IPA, audio, sources, and alternatives
 
 </details>
 


### PR DESCRIPTION
## Summary

Add the mature `pronounce-word` Agent Skill to **Community Skills → Development and Testing**. It uses a 1,900+ entry source-backed dictionary and the cross-platform `say-it` CLI to answer developer-jargon pronunciation questions with IPA, audio, citations, and contested alternatives.

The linked skill is documented, MIT-licensed, actively maintained, published as part of release `v2.28.1`, and already used through the project’s CLI, MCP server, VS Code extension, GitHub Action, and agent integrations.

## Validation

- description is 9 words, within the 10-word limit
- link resolves to the public `SKILL.md` directory
- entry is appended to the matching community subcategory
- `git diff --check` passes