### PR TITLE
Add x402-list skill to Community Skills > Specialized Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1938,6 +1938,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 - **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
+- **[mcccsm/x402-list-mcp](https://github.com/mcccsm/x402-list-mcp)** - Discover and verify x402 payment APIs before an agent pays
 
 </details>
 


### PR DESCRIPTION
Adds the x402-list agent skill under Community Skills > Specialized Domains.

x402-list ships a `SKILL.md` (github.com/mcccsm/x402-list-mcp, `name: x402-list`) that lets an agent discover and verify APIs accepting x402 (HTTP 402 stablecoin) payments before it pays: search and rank services by uptime, price, and x402 compliance, read on-chain-verified facilitator settlement volume, and watch a drift feed of price, payTo, and schema changes. Read-only over the public x402-list API, no key needed. It also runs as an MCP server (npx -y x402-list-mcp) and a hosted Streamable HTTP endpoint at https://mcp.x402-list.com/mcp.

- Repo / SKILL.md: https://github.com/mcccsm/x402-list-mcp (MIT)
- Homepage: https://x402-list.com

No existing entry for this skill in the list.
