### PR TITLE
Add skill: azeemkafridi/bulkpublish-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1722,6 +1722,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[YannisKiefer/dark-psychology-skills](https://github.com/YannisKiefer/dark-psychology-skills)** - 13 sales and negotiation skills for agents distilled from 36 books (CIA psyop manuals, FBI behavioral research, propaganda science, persuasion classics); every tactic passes an honest-influence filter: it must still work when fully disclosed
 - **[SupercmoHQ/superCMO-skills](https://github.com/SupercmoHQ/superCMO-skills)** - Open-source skills + local MCP server for marketing video & image production: UGC videos, ad videos, product photography, and image ads from a product photo and a brief; casts AI actors, picks the best image/video models, edits any-length clips with consistent actor and product, and researches competitor ads. BYO or managed keys, Apache-2.0
 - **[sandbaseai/sandbase-skills/multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/main/research/multi-source-search)** - Evidence-led multi-source research with offline validation
+- **[azeemkafridi/bulkpublish-api](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills)** - Social-media skills for AI-agent research, creation, publishing, and analytics
 
 </details>
 


### PR DESCRIPTION
Adds BulkPublish’s reusable social-media content skills to the Community Skills → Marketing section. The linked collection covers AI-agent research, content creation, repurposing, publishing, scheduling, review, and analytics.\n\nSkills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills\nAPI: https://github.com/azeemkafridi/bulkpublish-api\nMCP docs: https://app.bulkpublish.com/docs\n\nDisclosure: I am affiliated with BulkPublish and am submitting this skill collection for consideration.