### PR TITLE
Add skill: chrono-meta/salience-splitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1883,6 +1883,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[khendzel/skills-janitor](https://github.com/khendzel/skills-janitor)** - Token audit, usage tracking, and swipe-to-delete skill pruning.
 - **[oliver-zehentleitner/keep-the-why](https://github.com/oliver-zehentleitner/keep-the-why)** - Preserves the reasoning behind a codebase — decisions, workarounds, rejected alternatives
 - **[chrono-meta/context-doctor](https://github.com/chrono-meta/forge-harness/tree/main/plugins/fh-meta/skills/context-doctor)** - Generates .claudeignore and flags context bloat before it costs tokens
+- **[chrono-meta/salience-splitter](https://github.com/chrono-meta/forge-harness/tree/main/plugins/fh-meta/skills/salience-splitter)** - Splits bloated CLAUDE.md or SKILL.md into resident and on-demand layers
 - **[thousandflowers/skillreaper](https://github.com/thousandflowers/skillreaper)** - Prunes unused skills, MCP servers, and subagents from transcript evidence
 - **[orziz/odai](https://github.com/orziz/odai/tree/main/skills/odai)** - Govern evidence, responsibility routing, safety boundaries, and verified delivery
 - **[thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)** - Compresses and persists agent memory across sessions


### PR DESCRIPTION
Adds one skill under **Community Skills → Context Engineering**, right after `chrono-meta/context-doctor` (#928):

```markdown
- **[chrono-meta/salience-splitter](https://github.com/chrono-meta/forge-harness/tree/main/plugins/fh-meta/skills/salience-splitter)** - Splits bloated CLAUDE.md or SKILL.md into resident and on-demand layers
```

**What it does.** When an always-loaded file (a `CLAUDE.md`, a `SKILL.md`, a memory index) has grown past what every session should pay for, this skill decides which parts are actually needed *on every turn* and which are only needed *when a specific situation comes up*, then moves the second group into a detail file behind explicit "read this when…" pointers. The split criterion is when content is needed, not how long it is — a short paragraph that governs a gate stays resident; a long evidence trail moves out. It verifies afterwards that every pointer has a matching header and nothing was orphaned. It sits one step downstream of `context-doctor`: that one tells you the file is bloated, this one does the surgery.

**Format and requirements.** Public repo, MIT. `SKILL.md` (275 lines) plus a detail file; explicit tool list, no absolute paths, third-person description now trimmed to ~90 tokens; link returns 200; one skill, appended to the end of the subcategory; title follows the convention.

**On the community-usage bar — the honest version.** The harness it lives in has been public since June, ships on npm as `@chrono-meta/fh-gate`, is listed in `walkinglabs/awesome-harness-engineering`, and gets outside PRs. The skill itself has existed since 2026-06-02 (renamed from `skill-splitter` in July) and is used routinely inside that harness — its own `CLAUDE.md` was split with it — but the only other repository that references it is a sister harness by the same author. So I can't show independent adoption for this specific skill, and if that's the bar you apply per-skill, declining is entirely fair. I'm submitting because everything else is in order and the skill genuinely works on its own.

**I checked that last claim before opening this.** Empty git repo, the skill copied into `.claude/skills/`, a 154,811-byte `CLAUDE.md`, one run at Sonnet: 17,827 bytes moved into a detail file under seven named sections, 7 pointers ↔ 7 headers cross-checked both ways, no orphans. One limitation the skill reported itself: its rule for ambiguous content is "keep it unless an ablation experiment says otherwise", and that experiment runner isn't part of the skill — so a standalone run is conservative (here about −7%) and the bigger cuts need the full harness. Usable on its own and as strong as inside the harness are two different claims; I'm only making the first.

Happy to adjust the wording or placement if you'd prefer it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbEh8nWo7ApJuMrF2cFuRg
