### PR TITLE
Add skill: n3wth/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1856,6 +1856,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[n3wth/skills](https://github.com/n3wth/skills)** - AI coding assistant skills with a live registry at skills.n3wth.com
 
 </details>
 


### PR DESCRIPTION
Adds [n3wth/skills](https://github.com/n3wth/skills) to Community Skills → Development and Testing.

AI coding assistant skills with a live registry at https://skills.n3wth.com
