### PR TITLE
Add skill: Tencent/aig-agent-redteam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1938,6 +1938,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 - **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
+- **[Tencent/aig-agent-redteam](https://github.com/Tencent/AI-Infra-Guard/tree/main/skills/aig-agent-redteam)** - One-command Agent red-team security assessment skill
 
 </details>
 


### PR DESCRIPTION
Adding a real, installable Agent Skill to Specialized Domains, following the same pattern as the existing security entries there (prompt-security/clawsec, BehiSecc/vibesec).

- **Name of Project/Resource:** aig-agent-redteam
- **Section:** Specialized Domains
- **Link:** https://github.com/Tencent/AI-Infra-Guard/tree/main/skills/aig-agent-redteam
- **Short Description:** One-command Agent red-team security assessment skill

## Why is this awesome?
Installs into an Agent client (Claude Code, CodeBuddy, Cursor, etc. — via `npx skills add`) and lets the agent attack itself: prompt injection, indirect injection, tool abuse, data leakage, privilege escalation, SSRF, supply-chain risk, and infra exposure. Uses first-principles red-team reasoning (model capabilities/trust boundaries → attack hypotheses → minimal-harm verification → evidence-backed report) rather than replaying a static payload library. Backed by Tencent Zhuque Lab's AI-Infra-Guard (Apache-2.0, github.com/Tencent/AI-Infra-Guard), an established open-source AI red-teaming platform already integrated into OpenClaw's ClawHub scanning pipeline.

## Checklist
- [x] The entry is not a duplicate
- [x] Public repository with a working skill
- [x] Has documentation (README.md, README.zh-CN.md, and SKILL.md)
- [x] Author/org prefix included in the name
- [x] Description is 10 words or fewer
- [x] I have read the contributing guidelines

Happy to adjust placement or wording if this doesn't meet the quality/maturity bar yet — no problem if you'd rather wait for more independent usage signal first.