### PR TITLE
Add skill: Continuum-AI-Corp/orca-replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1856,6 +1856,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[Continuum-AI-Corp/orca-replay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay)** - Answer questions about past agent runs from their recordings
 
 </details>
 


### PR DESCRIPTION
Adds one line to the end of **Community Skills → Development and Testing**.

```
- **[Continuum-AI-Corp/orca-replay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay)** - Answer questions about past agent runs from their recordings
```

## Against the requirements

- **Public repository with a working skill** — <https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay>, on `main`, resolves.
- **Has documentation** — `SKILL.md` plus the tool's own README; validated with the agentskills reference implementation (`skills-ref validate` → `Valid skill`).
- **Author/org prefix included** — `Continuum-AI-Corp/orca-replay`.
- **Description 10 words or fewer** — 9.
- **Real community usage** — ❌ **not met, and I want to be straight about it rather than have you find out.**

## On the adoption requirement

Your CONTRIBUTING says brand new skills are not accepted and to let a skill mature first. This one is days old and has no users yet, so by that rule it does not qualify today.

I am submitting anyway because the maintainer of the project asked me to put it in front of you rather than sit on it. That is a decision you should not have to pay for: **close it in five seconds if the answer is no** — no explanation needed, and I will not re-open or re-submit. If you would rather I come back when it has traction, say so and I will treat that as the answer.

## What it is, in case it is worth keeping on the radar

OrcaReplay records a coding-agent run below the harness — the model API through a local proxy, plus shell exit codes, per-turn file changes and MCP traffic on one timeline — and replays it offline byte-for-byte or forks it from a checkpoint onto another model. The skill is the layer that tells an agent to answer "why did you delete that file" from the recording instead of reconstructing it from context, to keep the causal graph's `recorded` and `inferred` labels apart in its answer, and to disclose what gets uploaded before any cross-model comparison.

Apache-2.0, npm `orcareplay`, MCP server included.

Disclosure: I work on OrcaReplay.
