### PR TITLE
Add skills: johnsmithCA-sta/skill-dev-kit and privacy-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1856,6 +1856,8 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[lindblomstefan/skills-library](https://github.com/lindblomstefan/skills-library)** - Guided discovery skill for Claude Code: runs an interview to recommend from a catalog of 100+ AI skills; records session feedback that validates candidates over time
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
 - **[dannwaneri/spec-writer](https://github.com/dannwaneri/spec-writer)** - Turns vague requests into spec, plan, and tasks
+- **[johnsmithCA-sta/skill-dev-kit](https://github.com/johnsmithCA-sta/skill-dev-kit)** - Release toolkit for authoring Agent Skills: 16-item pre-publish gate (secrets, attribution, IP), packaging, tag protection, trigger-phrase evaluation and an eval loop. Pure Python stdlib, zero dependencies
+- **[johnsmithCA-sta/privacy-audit](https://github.com/johnsmithCA-sta/privacy-audit)** - Pre-publish PII gate for Agent Skills and codebases: L1 scans 17 sensitive field types plus 5 credential formats with MOD11-2/Luhn/GB32100 anti-false-positive, L2 runs a six-dimension PIPL/GDPR review. CI-friendly exit codes
 
 </details>
 


### PR DESCRIPTION
Adds two community skills to the **Development and Testing** category, appended at the end of the subcategory per CONTRIBUTING.

- `johnsmithCA-sta/skill-dev-kit` — release toolkit for authoring Agent Skills: pre-publish gate (secrets, attribution, IP), packaging, tag protection, trigger-phrase evaluation, eval loop. Pure Python stdlib, zero third-party dependencies.
- `johnsmithCA-sta/privacy-audit` — pre-publish PII gate for Agent Skills and codebases: L1 scans 17 sensitive field types plus 5 credential formats with MOD11-2/Luhn/GB32100 anti-false-positive, L2 runs a six-dimension PIPL/GDPR review. CI-friendly exit codes.

Checklist against CONTRIBUTING:

- [x] Author/org prefix included in both names
- [x] Both have documentation (README.md and SKILL.md)
- [x] Real community usage: both are distributed on a public skill registry (skillhub.cn) with existing install volume — 88 and 28 downloads respectively
- [x] Not new/untested: published in August 2026, iterated through multiple releases
- [x] Links verified working at time of submission
- [x] No paid product, affiliate or referral links in either repository

Both are MIT licensed.