### PR TITLE
Add skill: amirkiarafiei/subagent-cli-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,6 +1887,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[orziz/odai](https://github.com/orziz/odai/tree/main/skills/odai)** - Govern evidence, responsibility routing, safety boundaries, and verified delivery
 - **[thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)** - Compresses and persists agent memory across sessions
 - **[vshulcz/deja-history](https://github.com/vshulcz/deja-vu/tree/main/claude-plugin/skills/deja-history)** - Searches your own past sessions across 20 coding agents
+- **[amirkiarafiei/subagent-cli-skills](https://github.com/amirkiarafiei/subagent-cli-skills/tree/main/skills)** - Delegate heavy work to 15 other agent CLIs as subagents
 
 </details>
 


### PR DESCRIPTION
Adds one entry to **Community Skills → Context Engineering**.

```
- **[amirkiarafiei/subagent-cli-skills](https://github.com/amirkiarafiei/subagent-cli-skills/tree/main/skills)** - Delegate heavy work to 15 other agent CLIs as subagents
```

### What it is

15 skills that let the agent you're already in delegate a task to a **different vendor's CLI agent** running headless — Antigravity, Codex, Gemini, Copilot, Cursor, Kiro, OpenHands, OpenCode, Qwen, Junie, Mistral Vibe, Kimi, Qoder, Hermes and Claude Code. One skill per CLI, each with a `SKILL.md` and a `reference.md` of verified flags.

### Why it fits Context Engineering

It is a context-offloading tool. Broad searches, log trawls, long refactors and research passes are exactly what bloats an orchestrator's context window and its bill. These skills push that work into an isolated headless process and return only the summary, so the main agent stays lean and keeps the strategic thread.

It also gives one central place to connect agents across providers, rather than a separate ad-hoc integration per vendor — whichever agent a developer starts from can reach the others.

### Checklist

- [x] Public repository with working skills (MIT)
- [x] Documentation — repo README plus per-skill `SKILL.md` and `reference.md`
- [x] Author prefix included in the name
- [x] Description is 10 words
- [x] Appended to the end of the subcategory
- [x] Links verified (both return 200)

---

*Transparency: this pull request was opened and its text written by Claude (Claude Code) on behalf of the repository author. The author will follow up in a comment.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)