### PR TITLE
Add skill: anthonyandrei/offload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1887,6 +1887,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[orziz/odai](https://github.com/orziz/odai/tree/main/skills/odai)** - Govern evidence, responsibility routing, safety boundaries, and verified delivery
 - **[thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)** - Compresses and persists agent memory across sessions
 - **[vshulcz/deja-history](https://github.com/vshulcz/deja-vu/tree/main/claude-plugin/skills/deja-history)** - Searches your own past sessions across 20 coding agents
+- **[anthonyandrei/offload](https://github.com/anthonyandrei/offload)** - Delegate coding and research tasks to isolated headless Gemini workers
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1915,7 +1915,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[orziz/odai](https://github.com/orziz/odai/tree/main/skills/odai)** - Govern evidence, responsibility routing, safety boundaries, and verified delivery
 - **[thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)** - Compresses and persists agent memory across sessions
 - **[vshulcz/deja-history](https://github.com/vshulcz/deja-vu/tree/main/claude-plugin/skills/deja-history)** - Searches your own past sessions across 20 coding agents
-- **[anthonyandrei/offload](https://github.com/anthonyandrei/offload)** - Delegate bounded coding and research work with orchestrator review
+- **[anthonyandrei/offload](https://github.com/anthonyandrei/offload)** - Bounded coding and research with pre-delegation offers and orchestrator review
 - **[rebelytics/task-observer](https://github.com/rebelytics/one-skill-to-rule-them-all)** - Meta-skill for continuous skill improvement & automatic skill creation.
 
 </details>


### PR DESCRIPTION
## Summary

- Add `anthonyandrei/offload` to Community Skills → Context Engineering.
- Describe bounded coding and research work with pre-delegation offers and orchestrator review.
- Keep worker, model, and effort selection runtime-dynamic.

Repository: https://github.com/anthonyandrei/offload

## Source contract

The catalog entry matches the source skill's current contract. Offload offers once before native multi-agent delegation for two or more independent, bounded assignments, requires consent before dispatch, and lets native delegation continue after a decline.