### PR TITLE
Add wufufu770/skills and wufufu770/prompt-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1685,6 +1685,15 @@ Official skills published by Cypress to help create, maintain, understand, and f
 ### Community Skills
 
 <details>
+<summary><h3 style="display:inline">Security & Penetration Testing</h3></summary>
+
+- **[wufufu770/skills](https://github.com/wufufu770/skills)** - Authorized security-testing arsenal: Tri-Ring parallel orchestration (discovery/attack/creative rings + arbitration gates) across Claude Code, Codex, opencode, and Pi; 31 mainline skills, CNVD/EduSRC report templates with evidence gates
+- **[wufufu770/prompt-skill](https://github.com/wufufu770/prompt-skill)** - Spec-generation skill system (shared kernel + 14 domain shells): turns a vague requirement into a workable, acceptance-testable engineering spec with EARS acceptance syntax, evidence gates, and behavior evals
+
+</details>
+
+
+<details>
 <summary><h3 style="display:inline">Vector Databases</h3></summary>
 
 - **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java


### PR DESCRIPTION
### What

Adding two self-authored, MIT-licensed skill collections:

1. **[wufufu770/skills](https://github.com/wufufu770/skills)** — Authorized security-testing skill arsenal. Tri-Ring parallel orchestration (breadth-discovery ring / depth-attack ring / creative-exploration ring + arbitration gates) packaged for Claude Code, Codex, opencode, and Pi. 31 mainline skills, CNVD/EduSRC report templates with submission-time evidence gates, audit CI, and 187 upstream methodology skills as shared ammo.

2. **[wufufu770/prompt-skill](https://github.com/wufufu770/prompt-skill)** — Engineering spec-generation skill system: a shared kernel (falsification-column encoding, EARS acceptance syntax, clarify-marker protocol, evidence gates) + 14 domain shells that turn a vague one-liner into a workable, acceptance-testable spec. Ships with static integrity lint, promptfoo behavior probes, and Claude Code plugin manifests.

### Why here

- skills targets Claude Code natively (self-contained per-host tree, one-line installer into the skills directory).
- prompt-skill uses the standard SKILL.md agent-skills format with .claude-plugin manifests.

Self-submission of my own repos (both MIT). Happy to adjust wording/sections per maintainer preference.