### PR TITLE
Add kavel-image skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1954,6 +1954,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 - **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
+- **[hanshs474/kavel-image-skill](https://github.com/hanshs474/kavel-image-skill)** - Generate images and edit photos from a prompt with no API key and no account, through Kavel's anonymous endpoint — text-to-image plus face-preserving edits
 
 </details>
 


### PR DESCRIPTION
Adds [kavel-image](https://github.com/hanshs474/kavel-image-skill) under **<summary><h3 style="display:inline">Specialized Domains</h3></summary>**.

Generates images and edits photos with **no API key and no account** — most image skills need a provider key before they do anything. It calls an anonymous endpoint, so a fresh install produces a picture on the first call (15 free credits, 5 per text-to-image; output is 1K and watermarked, which the skill states plainly).

The SKILL.md documents the real limits rather than the happy path: which model can and cannot take an image input, that the anonymous wallet cannot cover video at any setting, and the three failure modes that actually occur (content-filter refusal, queue waits, per-IP daily ceiling).

MIT licensed.