### PR TITLE
Add skill: yuzu-octopus/ctf-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1954,6 +1954,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[apitube/news-api-skills](https://github.com/apitube/news-api-skills)** - Search worldwide news by keyword, entity, sentiment, source, date
 - **[zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout)** - Official Zinc API (zinc.com) checkout across 50+ US retailers
 - **[swaylq/humanize-chinese](https://github.com/swaylq/humanize-chinese)** - Detect and rewrite AI-generated Chinese text, fully offline, no LLM
+- **[yuzu-octopus/ctf-skills](https://github.com/yuzu-octopus/ctf-skills)** - Agent skills suite for solving CTF challenges across 10 categories
 
 </details>
 


### PR DESCRIPTION
### Add Skill: yuzu-octopus/ctf-skills

- **Repository**: https://github.com/yuzu-octopus/ctf-skills
- **Category**: Community Skills > Specialized Domains
- **Description**: Agent skills suite for solving CTF challenges across 10 categories (Web, Pwn, Pure-Python Crypto, Rev, Forensics, OSINT, AI-ML).
- **Format**: Follows Agent Skills open standard (`SKILL.md` specification). Tested and compatible with Claude Code, Cursor, Codex, and all `skills.sh` supported agents.