### PR TITLE
Add skill: lizard-build/skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1967,6 +1967,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[czlonkowski/n8n-node-configuration](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-node-configuration)** - Node configuration with dependency rules and AI connections
 - **[czlonkowski/n8n-validation-expert](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-validation-expert)** - Fix n8n validation errors with error catalog
 - **[czlonkowski/n8n-workflow-patterns](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-workflow-patterns)** - Workflow patterns for webhook, HTTP, database, and AI tasks
+- **[lizard-build/skill](https://github.com/lizard-build/skill)** - Deploy and manage apps on Lizard from your agent
 
 </details>
 


### PR DESCRIPTION
Adds Lizard Skill, the official agent skill for Lizard (https://lizard.build).

Disclosure: I maintain this skill.

- Public repo with a working skill: https://github.com/lizard-build/skill (MIT)
- Documentation: README plus SKILL.md
- Author/org prefix included in the name
- Description is 9 words

The skill is a bootstrap: SKILL.md pulls the full guide from the installed CLI at runtime, so an agent's instructions always match the CLI version instead of a stale copy. It works with Claude Code, Cursor, Codex, Copilot and Gemini CLI.

On the community-usage requirement, being straight with you: the repo has been public since June and ships with every Lizard CLI install, but it has few GitHub stars of its own. If that falls short of your bar, feel free to close this and I will resubmit once it has more traction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)