### PR TITLE
Add 3 marketing skills: competitor-xray, inbox-audit, agent-stack-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,6 +908,9 @@ Official marketing skills by [Corey Haines](https://github.com/coreyhaines31), c
 - **[coreyhaines31/signup](https://github.com/coreyhaines31/marketingskills/tree/main/skills/signup)** - Optimize signup, registration, and trial activation flows for higher conversion
 - **[coreyhaines31/site-architecture](https://github.com/coreyhaines31/marketingskills/tree/main/skills/site-architecture)** - Plan and restructure page hierarchy, navigation, and URL structure
 - **[coreyhaines31/social](https://github.com/coreyhaines31/marketingskills/tree/main/skills/social)** - Create and schedule social media content for LinkedIn, Twitter/X, and Instagram
+- **[Axel-freeman-marketing-framework/competitor-xray](https://github.com/Axel-freeman-marketing-framework/competitor-xray)** - Competitor research that ends in a weekly copy-list, not a report. Free methods only
+- **[Axel-freeman-marketing-framework/inbox-audit](https://github.com/Axel-freeman-marketing-framework/inbox-audit)** - Free DNS deliverability audit for any domain: SPF/DKIM/DMARC checks with paste-ready fixes
+- **[Axel-freeman-marketing-framework/agent-stack-starter](https://github.com/Axel-freeman-marketing-framework/agent-stack-starter)** - Self-hosted AI marketing stack in one evening: docker-compose, skills, scheduled jobs
 
 </details>
 


### PR DESCRIPTION
Adding 3 skills from the **Axel Freeman marketing framework** ([verified org](https://github.com/Axel-freeman-marketing-framework)):

- **[competitor-xray](https://github.com/Axel-freeman-marketing-framework/competitor-xray)** — competitor research that ends in a weekly copy-list, not a report; free methods only
- **[inbox-audit](https://github.com/Axel-freeman-marketing-framework/inbox-audit)** — free DNS deliverability audit (SPF/DKIM/DMARC + paste-ready fixes); includes standalone bash script
- **[agent-stack-starter](https://github.com/Axel-freeman-marketing-framework/agent-stack-starter)** — self-hosted AI marketing stack: docker-compose, skills, scheduled jobs, day-one output

Companion to [axelfreeman/marketing-mindset](https://github.com/axelfreeman/marketing-mindset) (15,000+ installs on skills.sh). All installable via `npx skills add <owner>/<repo>`.