### PR TITLE
docs: add Awesome WorkBuddy directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1973,6 +1973,14 @@ Official skills published by Cypress to help create, maintain, understand, and f
 
 
 
+<details>
+<summary><h3 style="display:inline">WorkBuddy</h3></summary>
+
+- **[Awesome WorkBuddy](https://github.com/sandbaseai/awesome-workbuddy)** - Bilingual directory of Tencent WorkBuddy documentation, Skills, MCP integrations, workflows, and independently reviewed ecosystem resources.
+
+</details>
+
+
 ## 🔒 Security Notice
 
 Skills in this list are curated, not audited. They may be updated, modified, or replaced by their original maintainers at any time after being added here.


### PR DESCRIPTION
## Summary

- Add Awesome WorkBuddy to the Community Skills section
- Describe its bilingual Tencent WorkBuddy documentation, Skills, MCP, workflows, and independent review scope

This is a small README-only addition and does not change the skill catalog or runtime behavior.
