### PR TITLE
Add skill: Finn763/pit-stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1884,6 +1884,7 @@ Official skills published by Cypress to help create, maintain, understand, and f
 - **[d1vai/d1v](https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md)** - Deploy web projects with verified previews and confirmed production releases
 - **[Kayforkind/reimagine-it](https://github.com/Kayforkind/reimagine-it)** - Redesigns existing HTML pages from their own content
 - **[scarletkc/agents](https://github.com/scarletkc/agents)** - Reusable standards and workflow skills for AI coding agents
+- **[Finn763/pit-stop](https://github.com/Finn763/pit-stop)** - Autonomous improve-fix-verify-report loop for any codebase
 
 </details>
 


### PR DESCRIPTION
Add [Finn763/pit-stop](https://github.com/Finn763/pit-stop) to Development and Testing.

One-line instruction runs a full codebase improvement loop (read → find → fix → verify → report) with evidence-before-claims reporting and no mid-run questions. Cross-runtime: Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Hermes, Pi. Install: `npx skills add Finn763/pit-stop`.